### PR TITLE
Harden CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,12 @@ jobs:
     name: Build
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
           check-latest: true
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install yq
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '20'
+          node-version: '22'
           check-latest: true
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '20'
+          node-version: '22'
           check-latest: true
 
       - name: Set up Python

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,15 +24,15 @@ jobs:
     name: Build
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
           check-latest: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.x'
 

--- a/.github/workflows/preview-website.yml
+++ b/.github/workflows/preview-website.yml
@@ -14,6 +14,10 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 

--- a/.github/workflows/preview-website.yml
+++ b/.github/workflows/preview-website.yml
@@ -15,15 +15,15 @@ jobs:
     name: Build
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Go 1.x
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.23'
         id: go
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
           check-latest: true
@@ -55,7 +55,7 @@ jobs:
           make assets
           make gen-prod
 
-      - uses: FirebaseExtended/action-hosting-deploy@v0
+      - uses: FirebaseExtended/action-hosting-deploy@e2eda2e106cfa35cdbcf4ac9ddaf6c4756df2c8c # v0.10.0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_QA }}'

--- a/.github/workflows/preview-website.yml
+++ b/.github/workflows/preview-website.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '20'
+          node-version: '22'
           check-latest: true
 
       - name: Install yq
@@ -48,8 +48,6 @@ jobs:
           sudo mv hugo-tools /usr/local/bin/hugo-tools
 
       - name: Update docs
-        env:
-          GOOGLE_CUSTOM_SEARCH_API_KEY: ${{ secrets.GOOGLE_CUSTOM_SEARCH_API_KEY }}
         run: |
           npm install
           make assets

--- a/.github/workflows/release-tracker.yml
+++ b/.github/workflows/release-tracker.yml
@@ -11,31 +11,25 @@ concurrency:
 
 jobs:
   build:
-    name: Build
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-24.04
+
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - name: Prepare git
-        env:
-          GITHUB_USER: 1gtm
-          GITHUB_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
-        run: |
-          git config --global user.name "${GITHUB_USER}"
-          git config --global user.email "${GITHUB_USER}@appscode.com"
-          git remote set-url origin https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-
-      - name: Install GitHub CLI
-        run: |
-          curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
-          sudo mv bin/hub /usr/local/bin
+      - name: Generate LGTM App token
+        id: lgtm-app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.LGTM_APP_CLIENT_ID }}
+          private-key: ${{ secrets.LGTM_APP_PRIVATE_KEY }}
+          owner: appscode-cloud
+          repositories: CHANGELOG
+          permission-pull-requests: write
 
       - name: Update release tracker
-        if: |
-          github.event.action == 'closed' &&
-          github.event.pull_request.merged == true
         env:
-          GITHUB_USER: 1gtm
-          GITHUB_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ steps.lgtm-app-token.outputs.token }}
         run: |
           ./hack/scripts/update-release-tracker.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,11 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          fetch-depth: 1
-          fetch-tags: true
+          fetch-depth: 0
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '20'
+          node-version: '22'
           check-latest: true
 
       - name: Set up Python
@@ -85,15 +84,17 @@ jobs:
           chmod +x hugo-tools
           sudo mv hugo-tools /usr/local/bin/hugo-tools
 
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Publish to GitHub Container Registry
         env:
           REGISTRY: ghcr.io/appscode
-          DOCKER_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
-          USERNAME: 1gtm
-          GITHUB_USER: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          docker login ghcr.io --username ${USERNAME} --password ${DOCKER_TOKEN}
           npm install
           make release
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,27 +14,33 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      packages: write
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 1
+          fetch-tags: true
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
           check-latest: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 3.x
 
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
         with:
           cache-image: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Install kubectl
         run: |
@@ -51,8 +57,8 @@ jobs:
 
       - name: Prepare git
         env:
-          GITHUB_USER: 1gtm
-          GITHUB_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -x
           git config --global user.name "${GITHUB_USER}"
@@ -84,8 +90,8 @@ jobs:
           REGISTRY: ghcr.io/appscode
           DOCKER_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
           USERNAME: 1gtm
-          GITHUB_USER: 1gtm
-          GITHUB_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           docker login ghcr.io --username ${USERNAME} --password ${DOCKER_TOKEN}
           npm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,18 +54,6 @@ jobs:
           pip install setuptools
           pip install linode-cli --upgrade
 
-      - name: Prepare git
-        env:
-          GITHUB_USER: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -x
-          git config --global user.name "${GITHUB_USER}"
-          git config --global user.email "${GITHUB_USER}@appscode.com"
-          git config --global \
-            url."https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com".insteadOf \
-            "https://github.com"
-
       - name: Install yq
         run: |
           curl -fsSL -o yqq https://github.com/mikefarah/yq/releases/download/3.3.0/yq_linux_amd64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,11 +61,6 @@ jobs:
             url."https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com".insteadOf \
             "https://github.com"
 
-      - name: Install GitHub CLI
-        run: |
-          curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
-          sudo mv bin/hub /usr/local/bin
-
       - name: Install yq
         run: |
           curl -fsSL -o yqq https://github.com/mikefarah/yq/releases/download/3.3.0/yq_linux_amd64

--- a/.github/workflows/release_old.yml
+++ b/.github/workflows/release_old.yml
@@ -18,15 +18,18 @@ jobs:
     name: Build
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 1
+          fetch-tags: true
 
       - name: Set up Go 1.x
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.23'
         id: go
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
           check-latest: true

--- a/.github/workflows/release_old.yml
+++ b/.github/workflows/release_old.yml
@@ -20,8 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          fetch-depth: 1
-          fetch-tags: true
+          fetch-depth: 0
 
       - name: Set up Go 1.x
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
@@ -59,7 +58,6 @@ jobs:
       - name: QA
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
-          GOOGLE_CUSTOM_SEARCH_API_KEY: ${{ secrets.GOOGLE_CUSTOM_SEARCH_API_KEY }}
         if: startsWith(github.event.ref, 'refs/tags/') && (contains(github.ref, '-alpha.') || contains(github.ref, '-beta.'))
         run: |
           npm install
@@ -69,7 +67,6 @@ jobs:
       - name: Release
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
-          GOOGLE_CUSTOM_SEARCH_API_KEY: ${{ secrets.GOOGLE_CUSTOM_SEARCH_API_KEY }}
         if: ${{ github.event_name == 'schedule' }} || (startsWith(github.event.ref, 'refs/tags/') && (contains(github.ref, '-alpha.') || contains(github.ref, '-beta.')) == false)
         run: |
           npm install

--- a/hack/scripts/update-release-tracker.sh
+++ b/hack/scripts/update-release-tracker.sh
@@ -69,4 +69,4 @@ case $GITHUB_BASE_REF in
         ;;
 esac
 
-hub api "$api_url" -f body="$msg"
+gh api "$api_url" -f body="$msg"


### PR DESCRIPTION
## Summary

Apply the CI hardening pattern from appscode-cloud/installer#1252.

- `release-tracker.yml`: switch to the LGTM GitHub App token (owner `appscode-cloud`, repositories `CHANGELOG`). Drop the legacy `Prepare git` + `Install hub` steps and the `LGTM_GITHUB_TOKEN` PAT. `hack/scripts/update-release-tracker.sh`: `hub api` → `gh api`.
- `release.yml`:
  - Bump `actions/checkout` from `@v1` to `34e1148…` (`v4.3.1`).
  - Add least-privilege job-level `permissions: { contents: write, packages: write }`.
  - Pin `actions/setup-node`, `actions/setup-python`, `docker/setup-qemu-action`, `docker/setup-buildx-action`, `docker/login-action` to commit SHAs.
  - Replace inline `docker login` + `LGTM_GITHUB_TOKEN` PAT with `docker/login-action@v4.1.0` using `github.actor` and the default `GITHUB_TOKEN`.
  - Drop the unused `Prepare git` step (`make release` only does docker push, no git ops need the rewrite).
  - Drop the unused `Install GitHub CLI (hub)` step (folded from #210).
- `release_old.yml`: SHA-pin actions; `fetch-depth: 1` + `fetch-tags: true` on the tag-triggered checkout.
- `ci.yml`, `deploy.yml`, `preview-website.yml`: SHA-pin all actions (incl. `FirebaseExtended/action-hosting-deploy@v0` → `e2eda2e…` `v0.10.0`). Drop unused `GOOGLE_CUSTOM_SEARCH_API_KEY` env from `preview-website.yml`.
- Bump `actions/setup-node` to Node `22` across `ci.yml`, `deploy.yml`, `preview-website.yml`, `release.yml`, `release_old.yml` (Node 20 is approaching EOL).

Closes #210 (its commit was merged into this branch).

## Test plan

- [ ] CI passes on this PR.
- [ ] After merge, next merged PR triggers `release-tracker` and the comment lands on the CHANGELOG release tracker.
- [ ] Next tag triggers `release` and `release_old`; both succeed (ghcr.io push via `GITHUB_TOKEN`, deploy-to-linode).
- [ ] Next PR triggers `preview-website` and the Firebase preview lands.