### PR TITLE
Drop unused hub CLI install from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,11 +61,6 @@ jobs:
             url."https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com".insteadOf \
             "https://github.com"
 
-      - name: Install GitHub CLI
-        run: |
-          curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
-          sudo mv bin/hub /usr/local/bin
-
       - name: Install yq
         run: |
           curl -fsSL -o yqq https://github.com/mikefarah/yq/releases/download/3.3.0/yq_linux_amd64


### PR DESCRIPTION
## Summary

- `.github/workflows/release.yml` installs the legacy `hub` CLI, but nothing in the workflow, Makefile, or release scripts invokes it. Removed the dead `Install GitHub CLI (hub)` step.
- `gh` ships preinstalled on GitHub-hosted runners if a future step needs a GitHub CLI.

Note: the only other `hub` references (in `.github/workflows/release-tracker.yml` and `hack/scripts/update-release-tracker.sh`) are already being removed by #209.

## Test plan

- [ ] Cut a tag and confirm the release workflow still succeeds (`make release`, `make deploy-to-linode`).