### PR TITLE
Quote NINJA_KUBECONFIG when writing kubeconfig

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,7 +82,7 @@ jobs:
           if [ "$CLUSTER" = "prod" ]; then
             linode-cli lke kubeconfig-view 326609 --json | jq -r .[0].kubeconfig | base64 -d > ~/.kube/config
           else
-            echo ${NINJA_KUBECONFIG} > ~/.kube/config
+            echo "${NINJA_KUBECONFIG}" > ~/.kube/config
           fi
           kubectl get nodes
           echo "deploy docker image"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,6 @@ jobs:
         run: |
           echo "connect to cluster"
           mkdir -p ~/.kube
-          echo ${NINJA_KUBECONFIG} > ~/.kube/config
+          echo "${NINJA_KUBECONFIG}" > ~/.kube/config
           kubectl get nodes
           make deploy-to-linode


### PR DESCRIPTION
## Summary
- Quote `${NINJA_KUBECONFIG}` in `release.yml` and `deploy.yml` so the multi-line YAML keeps its newlines when written to `~/.kube/config`.

The unquoted `echo ${NINJA_KUBECONFIG}` was word-splitting the secret on whitespace, collapsing newlines into spaces. That produced an invalid kubeconfig and caused the `v2026.6.12 Release` run to fail in "Deploy to QA":

```
error: error loading config file "/home/runner/.kube/config": yaml: mapping values are not allowed in this context
```

Ref: https://github.com/appscode/website/actions/runs/26952089345/job/79522602913

## Test plan
- [ ] Re-run the release workflow (or next tag) and confirm `kubectl get nodes` succeeds in "Deploy to QA".