### PR TITLE
Pin Node to 22.22.3 to fix firebase preview deploy auth

### DIFF
--- a/.github/workflows/preview-website.yml
+++ b/.github/workflows/preview-website.yml
@@ -29,8 +29,11 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '22'
-          check-latest: true
+          # Pin to 22.22.x: Node 22.23.0 / 24.17.0 ship a keep-alive socket
+          # regression (nodejs/node#63989) that breaks node-fetch, causing
+          # firebase auth to fail with "Premature close". 22.22.x is the
+          # latest known-good release.
+          node-version: '22.22.3'
 
       - name: Install yq
         run: |
@@ -62,7 +65,6 @@ jobs:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_QA }}'
           projectId: kubedb-new-e7965
-          firebaseToolsVersion: '13.35.1'
           # target: kubedb-new-e7965
           # entryPoint: '.'
         env:

--- a/.github/workflows/preview-website.yml
+++ b/.github/workflows/preview-website.yml
@@ -62,6 +62,7 @@ jobs:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_QA }}'
           projectId: kubedb-new-e7965
+          firebaseToolsVersion: '13.35.1'
           # target: kubedb-new-e7965
           # entryPoint: '.'
         env:


### PR DESCRIPTION
## Problem

The preview deploy job fails during Firebase authentication:

```
Error: Invalid response body while trying to fetch https://www.googleapis.com/oauth2/v4/token: Premature close
Error: Failed to authenticate, have you run firebase login?
```

The "Failed to authenticate" line is a misleading catch-all; the real error is the `Premature close` on the OAuth2 token fetch.

## Root cause (verified)

A **Node.js regression** — [nodejs/node#63989](https://github.com/nodejs/node/issues/63989) — shipped in the same-day security releases **Node 22.23.0** and **24.17.0**. It breaks keep-alive socket reuse, which surfaces as `ERR_STREAM_PREMATURE_CLOSE` in `node-fetch@2` — the transport used transitively by `google-auth-library` → `gaxios` → `node-fetch`. The firebase service-account token exchange runs through exactly this path, so auth fails.

Key points:
- **Independent of the firebase-tools version** — reproduced on firebase-tools 14.27 through 15.22.0 (see [firebase/firebase-tools#10681](https://github.com/firebase/firebase-tools/issues/10681), confirmed by a Firebase maintainer).
- Known-good Node: **22.22.x** or **24.16.x**. Broken: **22.23.0**, **24.17.0** (still the latest releases — no fixed-forward Node yet).
- Our CI was running **Node 22.23.0** (`check-latest: true` pulled the latest 22.x).

## Fix

Pin `actions/setup-node` to `22.22.3` (latest known-good 22.x) and drop `check-latest`. Revert to `check-latest`/floating once a fixed Node release lands.

Fixes the failure in [run 27901671685](https://github.com/appscode/website/actions/runs/27901671685/job/82564900073).